### PR TITLE
Captured image scale factor

### DIFF
--- a/DynamicBlurView/DynamicBlurView.swift
+++ b/DynamicBlurView/DynamicBlurView.swift
@@ -253,7 +253,6 @@ public class DynamicBlurView: UIView {
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0)
         let context = UIGraphicsGetCurrentContext()
-        CGContextSetInterpolationQuality(context, CGInterpolationQuality.None)
         CGContextTranslateCTM(context, -bounds.origin.x, -bounds.origin.y)
         
         if NSThread.currentThread().isMainThread {

--- a/DynamicBlurView/DynamicBlurView.swift
+++ b/DynamicBlurView/DynamicBlurView.swift
@@ -250,8 +250,8 @@ public class DynamicBlurView: UIView {
     
     private func capturedImage() -> UIImage! {
         let bounds = blurLayer.convertRect(blurLayer.bounds, toLayer: superview?.layer)
-        
-        UIGraphicsBeginImageContextWithOptions(bounds.size, true, 1)
+
+        UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0)
         let context = UIGraphicsGetCurrentContext()
         CGContextSetInterpolationQuality(context, CGInterpolationQuality.None)
         CGContextTranslateCTM(context, -bounds.origin.x, -bounds.origin.y)


### PR DESCRIPTION
I noticed that the captured image is pixelated with edge artefacts before blurring. 

With these changes, an image to be blurred is captured at a scale factor of the device's main screen. Also, I removed the interpolation quality setting, so it retains the quality of the image to be blurred. 

I have also compared `DynamicBlurView` with `FXBlurView`:
https://github.com/nicklockwood/FXBlurView/blob/master/FXBlurView/FXBlurView.m#L570-L592

`FXBlurView` has its own way to calculate the scale factor that needs to be passed to the image context.

Would it be better to provide an option to use a 1x scale factor `or` device's screen scale factor?
