### PR TITLE
Set CURRENT_PROJECT_VERSION to avoid validation error on submitting to the app store

### DIFF
--- a/DynamicBlurView.xcodeproj/project.pbxproj
+++ b/DynamicBlurView.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 		OBJ_31 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -375,6 +376,7 @@
 		OBJ_32 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
When you install this library via carthage, CFBundleVersion is missing because CURRENT_PROJECT_VERSION is not set.
This results in "Info.plist file is missing the required key: CFBundleVersion" error when you try to submit your app to the app store.

It looks like there are other libraries having this issue.
https://github.com/Flight-School/AnyCodable/issues/20#issuecomment-493263003